### PR TITLE
enh: increase coverage

### DIFF
--- a/nitransforms/linear.py
+++ b/nitransforms/linear.py
@@ -108,6 +108,13 @@ class Affine(TransformBase):
 
         Examples
         --------
+        >>> a = Affine()
+        >>> a.matrix
+        array([[[1., 0., 0., 0.],
+                [0., 1., 0., 0.],
+                [0., 0., 1., 0.],
+                [0., 0., 0., 1.]]])
+
         >>> xfm = Affine([[1, 0, 0, 4], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]])
         >>> ref = nb.load(testfile)
         >>> xfm.reference = ref
@@ -172,7 +179,34 @@ The moving image contains {0} volumes, while the transform is defined for \
         return moved_image
 
     def map_point(self, coords, index=0, forward=True):
-        """Apply y = f(x), where x is the argument `coords`."""
+        """
+        Apply y = f(x), where x is the argument `coords`.
+
+        Parameters
+        ----------
+        coords : array_like
+            RAS coordinates to map
+        index : int, optional
+            Transformation index
+        forward: bool, optional
+            Direction of mapping. Default is set to ``True``. If ``False``,
+            the inverse transformation is applied.
+
+        Returns
+        -------
+        out: ndarray
+            Transformed coordinates
+
+        Examples
+        --------
+        >>> xfm = Affine([[1, 0, 0, 1], [0, 1, 0, 2], [0, 0, 1, 3], [0, 0, 0, 1]])
+        >>> xfm.map_point((0,0,0))
+        array([1, 2, 3])
+
+        >>> xfm.map_point((0,0,0), forward=False)
+        array([-1., -2., -3.])
+
+        """
         coords = np.array(coords)
         if coords.shape[0] == self._matrix[index].shape[0] - 1:
             coords = np.append(coords, [1])

--- a/nitransforms/tests/test_base.py
+++ b/nitransforms/tests/test_base.py
@@ -1,0 +1,18 @@
+"""Tests of the base module"""
+import numpy as np
+
+from ..base import ImageSpace
+
+
+def test_ImageSpace(get_data):
+    im = get_data['RAS']
+
+    img = ImageSpace(im)
+    assert img.affine == np.linalg.inv(img.inverse)
+
+    # nd index / coords
+    idxs = img.ndindex
+    coords = img.ndcoords
+    assert len(idxs.shape) == len(coords.shape) == 2
+    assert idxs.shape[0] == coords.shape[0] == img.ndim == 3
+    assert idxs.shape[1] == coords.shape[1] == img.nvox == np.prod(im.shape)

--- a/nitransforms/tests/test_base.py
+++ b/nitransforms/tests/test_base.py
@@ -8,7 +8,7 @@ def test_ImageSpace(get_data):
     im = get_data['RAS']
 
     img = ImageSpace(im)
-    assert img.affine == np.linalg.inv(img.inverse)
+    assert np.all(img.affine == np.linalg.inv(img.inverse))
 
     # nd index / coords
     idxs = img.ndindex

--- a/nitransforms/tests/test_io.py
+++ b/nitransforms/tests/test_io.py
@@ -53,4 +53,4 @@ def test_LinearTransformArray(tmpdir, data_path):
 
     with open(outlta) as fp:
         lta2 = LTA.from_fileobj(fp)
-    np.allclose(lta['xforms'][0]['m_L'], lta2['xforms'][0]['m_L'])
+    assert np.allclose(lta['xforms'][0]['m_L'], lta2['xforms'][0]['m_L'])

--- a/nitransforms/tests/test_transform.py
+++ b/nitransforms/tests/test_transform.py
@@ -31,6 +31,27 @@ antsApplyTransforms -d 3 -r {reference} -i {moving} \
 }
 
 
+def test_map_voxel(tmpdir, get_data):
+    xfm = nbl.Affine([[1, 0, 0, 1], [0, 1, 0, 2], [0, 0, 1, 3], [0, 0, 0, 1]])
+    with pytest.raises(ValueError):
+        # reference / moving are not set
+        xfm.map_voxel((0, 0, 0))
+
+    img = get_data['RAS']
+    xfm.reference = img
+    assert xfm.map_voxel((0, 0, 0)) == (2.75, 5.5, 8.25)
+    del xfm
+
+    # use moving space as reference
+    xfm = nbl.Affine([[1, 0, 0, 1], [0, 1, 0, 2], [0, 0, 1, 3], [0, 0, 0, 1]])
+    mov = get_data['LPS']
+    assert xfm.map_voxel((0, 0, 0), moving=mov) == (-2.75, -5.5, 8.25)
+
+    # use RAS space as reference
+    xfm.reference = img
+    assert xfm.map_voxel((0, 0, 0), moving=mov) == (0.75, 5.0, 8.25)
+
+
 @pytest.mark.xfail(reason="Not fully implemented")
 @pytest.mark.parametrize('image_orientation', [
     'RAS', 'LAS', 'LPS',  # 'oblique',


### PR DESCRIPTION
bump up testing coverage, mainly for `base` and `linear` modules.

also adds a missing assertion for LTA test.