### PR TITLE
ENH: command line interface

### DIFF
--- a/nitransforms/base.py
+++ b/nitransforms/base.py
@@ -225,7 +225,7 @@ class TransformBase(object):
         order : int, optional
             The order of the spline interpolation, default is 3.
             The order has to be in the range 0-5.
-        mode : {'reflect', 'constant', 'nearest', 'mirror', 'wrap'}, optional
+        mode : {'constant', 'reflect', 'nearest', 'mirror', 'wrap'}, optional
             Determines how the input image is extended when the resamplings overflows
             a border. Default is 'constant'.
         cval : float, optional

--- a/nitransforms/cli.py
+++ b/nitransforms/cli.py
@@ -1,30 +1,49 @@
 from argparse import ArgumentParser, RawDescriptionHelpFormatter
 from textwrap import dedent
-
-import nibabel as nb
+import sys
 
 from .linear import load as linload
 from .nonlinear import load as nlinload
 
-def cli_apply(**kwargs):
+
+def cli_apply(pargs):
     """
     Apply a transformation to an image, resampling on the reference
 
-    Usage:
+    Sample usage:
 
-        $ nt apply moving.nii.gz xform.fsl --reference reference.nii.gz
+        $ nt apply xform.fsl moving.nii.gz --ref reference.nii.gz
+
+        $ nt apply warp.nii.gz moving.nii.gz --fmt afni --nonlinear
+
     """
-    try:
-        xfm = linload(xform)
-    except:
-        xfm = nlinload(xform)
+    fmt = pargs.fmt or pargs.transform.split('.')[-1]
+    if fmt == 'tfm':
+        fmt = 'itk'
+    elif fmt == 'lta':
+        fmt = 'fs'
 
-    xfm.apply(moving, **kwargs)
+    if fmt not in ('fs', 'itk', 'fsl', 'afni'):
+        raise RuntimeError(
+            "Cannot determine transformation format, manually set format with the `--fmt` flag"
+        )
+
+    if pargs.nonlinear:
+        xfm = nlinload(pargs.transform, fmt=fmt, reference=pargs.ref)
+    else:
+        xfm = linload(pargs.transform, fmt=fmt)
+
+    xfm.apply(
+        pargs.moving,
+        order=pargs.order,
+        mode=pargs.mode,
+        cval=pargs.cval,
+        prefilter=pargs.prefilter
+    )
 
 
 def get_parser():
-    desc = dedent(
-        """
+    desc = dedent("""
         NiTransforms command-line utility.
 
         Commands:
@@ -32,13 +51,13 @@ def get_parser():
             apply       Apply a transformation to an image
 
         For command specific information, use 'nt <command> -h'.
-        """
-    )
+    """)
 
     parser = ArgumentParser(
         description=desc, formatter_class=RawDescriptionHelpFormatter
     )
     subparsers = parser.add_subparsers(dest='command')
+
     def _add_subparser(name, description):
         subp = subparsers.add_parser(
             name,
@@ -52,18 +71,42 @@ def get_parser():
     applyp.add_argument(
         'moving', help='The image containing the data to be resampled'
     )
-    applyp.add_argument('reference', help='The reference space to resample onto')
-    applyp.add_argument('--order', help='The order of the spline transformation')
+    applyp.add_argument('--ref', help='The reference space to resample onto')
     applyp.add_argument(
-        '--mode', 
-        help='Determines how the input image is extended when the resampling overflows a border'
+        '--fmt',
+        choices=('itk', 'fsl', 'afni', 'fs'),
+        help='Format of transformation. If no option is passed, nitransforms will '
+        'estimate based on the transformation file extension.'
     )
-    applyp.add_argument('--cval', help='Constant used when using "constant" mode')
     applyp.add_argument(
-        '--prefilter', 
-        action='store_true', 
+        '--nonlinear', action='store_true', help='Transformation is nonlinear (default: False)'
+    )
+    applykwargs = applyp.add_argument_group('Apply customization')
+    applykwargs.add_argument(
+        '--order',
+        type=int,
+        default=3,
+        choices=range(6),
+        help='The order of the spline transformation (default: 3)'
+    )
+    applykwargs.add_argument(
+        '--mode',
+        choices=('constant', 'reflect', 'nearest', 'mirror', 'wrap'),
+        default='constant',
+        help='Determines how the input image is extended when the resampling overflows a border '
+        '(default: constant)'
+    )
+    applykwargs.add_argument(
+        '--cval',
+        type=float,
+        default=0.0,
+        help='Constant used when using "constant" mode (default: 0.0)'
+    )
+    applykwargs.add_argument(
+        '--prefilter',
+        action='store_false',
         help="Determines if the image's data array is prefiltered with a spline filter before "
-             "interpolation"
+        "interpolation (default: True)"
     )
     return parser
 
@@ -73,7 +116,7 @@ def main(pargs=None):
     pargs = parser.parse_args(pargs)
     if pargs.command is None:
         parser.print_help()
-        return
+        sys.exit(1)
 
     if pargs.command == 'apply':
-        cli_apply(**vars(pargs))
+        cli_apply(pargs)

--- a/nitransforms/cli.py
+++ b/nitransforms/cli.py
@@ -10,7 +10,7 @@ from .nonlinear import load as nlinload
 
 def cli_apply(pargs):
     """
-    Apply a transformation to an image, resampling on the reference
+    Apply a transformation to an image, resampling on the reference.
 
     Sample usage:
 
@@ -20,12 +20,12 @@ def cli_apply(pargs):
 
     """
     fmt = pargs.fmt or pargs.transform.split('.')[-1]
-    if fmt == 'tfm':
+    if fmt in ('tfm', 'mat', 'h5', 'x5'):
         fmt = 'itk'
     elif fmt == 'lta':
         fmt = 'fs'
 
-    if fmt not in ('fs', 'itk', 'fsl', 'afni'):
+    if fmt not in ('fs', 'itk', 'fsl', 'afni', 'x5'):
         raise ValueError(
             "Cannot determine transformation format, manually set format with the `--fmt` flag"
         )
@@ -83,7 +83,7 @@ def get_parser():
     applyp.add_argument('--ref', help='The reference space to resample onto')
     applyp.add_argument(
         '--fmt',
-        choices=('itk', 'fsl', 'afni', 'fs'),
+        choices=('itk', 'fsl', 'afni', 'fs', 'x5'),
         help='Format of transformation. If no option is passed, nitransforms will '
         'estimate based on the transformation file extension.'
     )

--- a/nitransforms/cli.py
+++ b/nitransforms/cli.py
@@ -1,6 +1,5 @@
 from argparse import ArgumentParser, RawDescriptionHelpFormatter
 import os
-import sys
 from textwrap import dedent
 
 

--- a/nitransforms/cli.py
+++ b/nitransforms/cli.py
@@ -126,9 +126,6 @@ def get_parser():
 def main(pargs=None):
     parser, subparsers = get_parser()
     pargs = parser.parse_args(pargs)
-    if not pargs.command or 'func' not in pargs:
-        parser.print_help()
-        sys.exit(1)
 
     try:
         pargs.func(pargs)

--- a/nitransforms/cli.py
+++ b/nitransforms/cli.py
@@ -1,0 +1,79 @@
+from argparse import ArgumentParser, RawDescriptionHelpFormatter
+from textwrap import dedent
+
+import nibabel as nb
+
+from .linear import load as linload
+from .nonlinear import load as nlinload
+
+def cli_apply(**kwargs):
+    """
+    Apply a transformation to an image, resampling on the reference
+
+    Usage:
+
+        $ nt apply moving.nii.gz xform.fsl --reference reference.nii.gz
+    """
+    try:
+        xfm = linload(xform)
+    except:
+        xfm = nlinload(xform)
+
+    xfm.apply(moving, **kwargs)
+
+
+def get_parser():
+    desc = dedent(
+        """
+        NiTransforms command-line utility.
+
+        Commands:
+
+            apply       Apply a transformation to an image
+
+        For command specific information, use 'nt <command> -h'.
+        """
+    )
+
+    parser = ArgumentParser(
+        description=desc, formatter_class=RawDescriptionHelpFormatter
+    )
+    subparsers = parser.add_subparsers(dest='command')
+    def _add_subparser(name, description):
+        subp = subparsers.add_parser(
+            name,
+            description=dedent(description),
+            formatter_class=RawDescriptionHelpFormatter,
+        )
+        return subp
+
+    applyp = _add_subparser('apply', cli_apply.__doc__)
+    applyp.add_argument('transform', help='The transform file')
+    applyp.add_argument(
+        'moving', help='The image containing the data to be resampled'
+    )
+    applyp.add_argument('reference', help='The reference space to resample onto')
+    applyp.add_argument('--order', help='The order of the spline transformation')
+    applyp.add_argument(
+        '--mode', 
+        help='Determines how the input image is extended when the resampling overflows a border'
+    )
+    applyp.add_argument('--cval', help='Constant used when using "constant" mode')
+    applyp.add_argument(
+        '--prefilter', 
+        action='store_true', 
+        help="Determines if the image's data array is prefiltered with a spline filter before "
+             "interpolation"
+    )
+    return parser
+
+
+def main(pargs=None):
+    parser = get_parser()
+    pargs = parser.parse_args(pargs)
+    if pargs.command is None:
+        parser.print_help()
+        return
+
+    if pargs.command == 'apply':
+        cli_apply(**vars(pargs))

--- a/nitransforms/tests/test_cli.py
+++ b/nitransforms/tests/test_cli.py
@@ -1,0 +1,66 @@
+from textwrap import dedent
+
+import pytest
+
+from ..cli import cli_apply, main as ntcli
+
+
+def test_cli():
+    # empty command
+    with pytest.raises(SystemExit):
+        ntcli()
+    # invalid command
+    with pytest.raises(SystemExit):
+        ntcli(['idk'])
+
+
+def test_help(capsys):
+    with pytest.raises(SystemExit) as sysexit:
+        ntcli(['-h'])
+    console = capsys.readouterr()
+    assert sysexit.value.code == 0
+    # possible commands
+    assert r"{apply}" in console.out
+
+    with pytest.raises(SystemExit):
+        ntcli(['apply', '-h'])
+    console = capsys.readouterr()
+    assert dedent(cli_apply.__doc__) in console.out
+
+
+def test_apply_linear(tmpdir, data_path, get_testdata):
+    tmpdir.chdir()
+    img = 'img.nii.gz'
+    get_testdata['RAS'].to_filename(img)
+    lin_xform = str(data_path / 'affine-RAS.itk.tfm')
+
+    # unknown transformation format
+    with pytest.raises(ValueError):
+        ntcli(['apply', 'unsupported.xform', 'img.nii.gz'])
+
+    # linear transform arguments
+    largs = ['apply', lin_xform, img, '--ref', img]
+    ntcli(largs)
+    output = 'nt_img.nii.gz'
+    assert (tmpdir / output).check()
+
+
+def test_apply_nl(tmpdir, data_path):
+    tmpdir.chdir()
+    img = str(data_path / 'tpl-OASIS30ANTs_T1w.nii.gz')
+    nl_xform = str(data_path / 'ds-005_sub-01_from-OASIS_to-T1_warp_afni.nii.gz')
+
+    nlargs = ['apply', nl_xform, img]
+    # format not specified
+    with pytest.raises(ValueError):
+        ntcli(nlargs)
+
+    nlargs.extend(['--fmt', 'afni'])
+    # no linear afni support
+    with pytest.raises(NotImplementedError):
+        ntcli(nlargs)
+
+    output = 'moved_from_warp.nii.gz'
+    nlargs.extend(['--nonlinear', '--out', output])
+    ntcli(nlargs)
+    assert (tmpdir / output).check()

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,10 @@ tests =
 all =
     %(test)s
 
+[options.entry_points]
+console_scripts =
+    nt = nitransforms.cli:main
+
 [flake8]
 max-line-length = 100
 ignore = D100,D101,D102,D103,D104,D105,D200,D201,D202,D204,D205,D208,D209,D210,D300,D301,D400,D401,D403,E24,E121,E123,E126,E226,E266,E402,E704,E731,F821,I100,I101,I201,N802,N803,N804,N806,W503,W504,W605


### PR DESCRIPTION
Closes #48 

Adds `nt` executable for command line usage of nitransforms.

Currently only supports `nt apply`, which applies a linear or nonlinear transform to an image.