### PR TITLE
MAINT: Add imports of modules in ``__init__.py`` to workaround #91

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -33,6 +33,7 @@ This release accompanies the `ISBI2020 preprint <https://doi.org/10.31219/osf.io
   * ENH: Revise doctests and get them ready for more thorough testing. (#10)
   * DOC: Add figure to JOSS draft / Add @smoia to author list (#61)
   * DOC: Initial JOSS draft (#47)
+  * MAINT: Add imports of modules in ``__init__.py`` to workaround #91 (#92)
   * MAINT: Fix missing python3 binary on CircleCI build job step (#85)
   * MAINT: Use setuptools_scm to manage versioning (#83)
   * MAINT: Split binary test-data out from gh repo (#84)

--- a/nitransforms/__init__.py
+++ b/nitransforms/__init__.py
@@ -16,8 +16,10 @@ Geometric transforms.
 
    transform
 """
-from .linear import Affine
+from . import linear, manip, nonlinear
+from .linear import Affine, LinearTransformsMapping
 from .nonlinear import DisplacementsFieldTransform
+from .manip import TransformChain
 
 try:
     from ._version import __version__
@@ -33,7 +35,12 @@ except ModuleNotFoundError:
 
 
 __all__ = [
+    "linear",
+    "manip",
+    "nonlinear",
     "Affine",
+    "LinearTransformsMapping",
     "DisplacementsFieldTransform",
+    "TransformChain",
     "__version__",
 ]

--- a/nitransforms/io/__init__.py
+++ b/nitransforms/io/__init__.py
@@ -15,8 +15,18 @@ Read and write transforms.
    :toctree: ../generated
 
    io
+
 """
+from . import afni, fsl, itk, lta
 from .lta import LinearTransform, LinearTransformArray, VolumeGeometry
 
 
-__all__ = ["LinearTransform", "LinearTransformArray", "VolumeGeometry"]
+__all__ = [
+    "afni",
+    "fsl",
+    "itk",
+    "lta",
+    "LinearTransform",
+    "LinearTransformArray",
+    "VolumeGeometry",
+]

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,6 @@ include_package_data = True
 test =
     pytest
     pytest-cov
-    nose
     codecov
 tests =
     %(test)s


### PR DESCRIPTION
Add modules to the ``__init__.py`` of root and ``nitransforms.io`` so
that they are visible for import.

References: #91