### PR TITLE
MAINT: scipy-1.8, numpy-1.22 require python 3.8

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -22,8 +22,10 @@ url = https://github.com/poldracklab/nitransforms
 [options]
 python_requires = >= 3.7
 install_requires =
-    numpy
-    scipy
+    numpy ~= 1.21.0; python_version<'3.8'
+    numpy ~= 1.21; python_version>'3.7'
+    scipy ~= 1.6.0;  python_version<'3.8'
+    scipy ~= 1.6; python_version>'3.7'
     nibabel >= 3.0
     h5py
 test_requires =


### PR DESCRIPTION
RTD is failing because it uses python 3.7.