### PR TITLE
FIX: Load arrays of linear transforms from FSL files

### DIFF
--- a/nitransforms/io/base.py
+++ b/nitransforms/io/base.py
@@ -1,4 +1,5 @@
 """Read/write linear transforms."""
+from pathlib import Path
 import numpy as np
 from nibabel import load as loadimg
 from scipy.io.matlab.miobase import get_matfile_version
@@ -174,3 +175,9 @@ def _read_mat(byte_stream):
     else:
         raise TransformFileError("Not a Matlab file.")
     return reader.get_variables()
+
+
+def _ensure_image(img):
+    if isinstance(img, (str, Path)):
+        return loadimg(img)
+    return img

--- a/nitransforms/io/fsl.py
+++ b/nitransforms/io/fsl.py
@@ -76,14 +76,14 @@ class FSLLinearTransform(LinearParameters):
 
     def to_ras(self, moving=None, reference=None):
         """Return a nitransforms internal RAS+ matrix."""
+        if reference is None:
+            raise ValueError("Cannot build FSL linear transform without a reference")
+
         if moving is None:
             warnings.warn(
                 "Converting FSL to RAS: moving image not provided, using reference."
             )
             moving = reference
-
-        if reference is None:
-            raise ValueError("Cannot build FSL linear transform without a reference")
 
         reference = _ensure_image(reference)
         moving = _ensure_image(moving)

--- a/nitransforms/linear.py
+++ b/nitransforms/linear.py
@@ -241,6 +241,8 @@ should be (0, 0, 0, 1), got %s."""
             _factory = io.itk.ITKLinearTransformArray
         elif fmt.lower() in ("lta", "fs"):
             _factory = io.LinearTransformArray
+        elif fmt.lower() == "fsl":
+            _factory = io.fsl.FSLLinearTransformArray
         else:
             raise NotImplementedError
 


### PR DESCRIPTION
Implements importing series of textfiles (<name>.000, ...) generated by FSL tools (e.g., MCFLIRT).

References: #40.