### PR TITLE
Fix #149 replace `_read_mat` with `scipy.io.loadmat`

### DIFF
--- a/nitransforms/io/base.py
+++ b/nitransforms/io/base.py
@@ -2,9 +2,6 @@
 from pathlib import Path
 import numpy as np
 from nibabel import load as loadimg
-from scipy.io.matlab.miobase import get_matfile_version
-from scipy.io.matlab.mio4 import MatFile4Reader
-from scipy.io.matlab.mio5 import MatFile5Reader
 
 from ..patched import LabeledWrapStruct
 
@@ -144,19 +141,6 @@ class DisplacementsField:
     def from_image(cls, imgobj):
         """Import a displacements field from a nibabel image object."""
         raise NotImplementedError
-
-
-def _read_mat(byte_stream):
-    mjv, _ = get_matfile_version(byte_stream)
-    if mjv == 0:
-        reader = MatFile4Reader(byte_stream)
-    elif mjv == 1:
-        reader = MatFile5Reader(byte_stream)
-    elif mjv == 2:
-        raise TransformFileError("Please use HDF reader for Matlab v7.3 files")
-    else:
-        raise TransformFileError("Not a Matlab file.")
-    return reader.get_variables()
 
 
 def _ensure_image(img):

--- a/nitransforms/io/itk.py
+++ b/nitransforms/io/itk.py
@@ -1,7 +1,7 @@
 """Read/write ITK transforms."""
 import warnings
 import numpy as np
-from scipy.io import savemat as _save_mat
+from scipy.io import loadmat as _read_mat, savemat as _save_mat
 from nibabel import Nifti1Header, Nifti1Image
 from nibabel.affines import from_matvec
 from .base import (
@@ -9,7 +9,6 @@ from .base import (
     DisplacementsField,
     LinearParameters,
     TransformFileError,
-    _read_mat,
 )
 
 LPS = np.diag([-1, -1, 1, 1])

--- a/nitransforms/tests/test_io.py
+++ b/nitransforms/tests/test_io.py
@@ -9,7 +9,7 @@ import filecmp
 import nibabel as nb
 from nibabel.eulerangles import euler2mat
 from nibabel.affines import from_matvec
-from scipy.io import loadmat, savemat
+from scipy.io import loadmat
 from ..io import (
     afni,
     fsl,
@@ -21,7 +21,7 @@ from ..io.lta import (
     FSLinearTransform as LT,
     FSLinearTransformArray as LTA,
 )
-from ..io.base import _read_mat, LinearParameters, TransformFileError
+from ..io.base import LinearParameters, TransformFileError
 
 LPS = np.diag([-1, -1, 1, 1])
 ITK_MAT = LPS.dot(np.ones((4, 4)).dot(LPS))
@@ -391,36 +391,6 @@ def test_LinearParameters(tmpdir):
 
     with pytest.raises(NotImplementedError):
         LinearParameters.from_fileobj(tmpdir.join("file.txt").open())
-
-
-@pytest.mark.parametrize("matlab_ver", ["4", "5"])
-def test_read_mat1(tmpdir, matlab_ver):
-    """Test read from matlab."""
-    tmpdir.chdir()
-
-    savemat("val.mat", {"val": np.ones((3,))}, format=matlab_ver)
-    with open("val.mat", "rb") as f:
-        mdict = _read_mat(f)
-
-    assert np.all(mdict["val"] == np.ones((3,)))
-
-
-@pytest.mark.parametrize("matlab_ver", [-1] + list(range(2, 7)))
-def test_read_mat2(tmpdir, monkeypatch, matlab_ver):
-    """Check read matlab raises adequate errors."""
-    from ..io import base
-
-    tmpdir.chdir()
-    savemat("val.mat", {"val": np.ones((3,))})
-
-    def _mockreturn(arg):
-        return (matlab_ver, 0)
-
-    with monkeypatch.context() as m:
-        m.setattr(base, "get_matfile_version", _mockreturn)
-        with pytest.raises(TransformFileError):
-            with open("val.mat", "rb") as f:
-                _read_mat(f)
 
 
 def test_afni_Displacements():


### PR DESCRIPTION
- Avoid `DeprecationWarning` by not using the `MatFile4Reader`/`MatFile5Reader` classes directly